### PR TITLE
Python3 compatibility

### DIFF
--- a/test.py
+++ b/test.py
@@ -18,7 +18,10 @@ f = closing(1)
 
 
 import threading
-import thread
+try:
+    import thread
+except ImportError:
+    import _thread as thread
 import time
 
 


### PR DESCRIPTION
Pursuant to [Pyninsula](https://pyninsula.org) project night, here's a patch that gets `test.py` running under Python3. The explorer works, too, but I haven't given it a real thorough testing. I think this is mergeable with very few side effects, but real py3 support will come with automated tests and tox.